### PR TITLE
Quick implementation of adding context to initialization failed error

### DIFF
--- a/ui/src/views/agent/AgentPage.tsx
+++ b/ui/src/views/agent/AgentPage.tsx
@@ -55,8 +55,8 @@ export const AgentPage = () => {
     }
   }, [config, ddClient]);
 
-  const handleFailure = () => {
-    sendAnalyticsEvent("Agent Failed to Start");
+  const handleFailure = (err: any) => {
+    sendAnalyticsEvent("Agent Failed to Start", {errorMessage: err?.message});
     createAgentConfig(ddClient, { ...config, enabled: false })
       .then(() => removeAkitaContainer(ddClient))
       .then(() => ddClient.desktopUI.toast.error("Failed to start Akita Agent."))

--- a/ui/src/views/agent/AgentPage.tsx
+++ b/ui/src/views/agent/AgentPage.tsx
@@ -56,7 +56,7 @@ export const AgentPage = () => {
   }, [config, ddClient]);
 
   const handleFailure = (err: any) => {
-    sendAnalyticsEvent("Agent Failed to Start", {errorMessage: err?.message});
+    sendAnalyticsEvent("Agent Failed to Start", { errorMessage: err?.message });
     createAgentConfig(ddClient, { ...config, enabled: false })
       .then(() => removeAkitaContainer(ddClient))
       .then(() => ddClient.desktopUI.toast.error("Failed to start Akita Agent."))

--- a/ui/src/views/agent/components/AgentStatus.tsx
+++ b/ui/src/views/agent/components/AgentStatus.tsx
@@ -19,7 +19,7 @@ interface AgentStatusProps {
   containerInfo?: ContainerInfo;
   isInitialized: boolean;
   onRestartAgent: () => void;
-  onFailure: () => void;
+  onFailure: (err) => void;
   onSettingsClick: () => void;
   onSendAnalyticsEvent: (
     eventName: string,
@@ -52,7 +52,7 @@ export const AgentStatus = ({
     // If the container has failed to start after multiple attempt, set the status to failed.
     if (hasInitializationFailed) {
       setStatus("Failed");
-      onFailure();
+      onFailure(new Error("hasInitializationFailed was true"));
     }
 
     // If the container is not initialized, set the status to starting.

--- a/vm/ports/router.go
+++ b/vm/ports/router.go
@@ -22,7 +22,7 @@ func NewRouter(app *app.App) *echo.Echo {
 
 	// Analytics Endpoints
 	{
-		router.POST("analytics/event", eventHandler.postEvent)
+		router.POST("/analytics/event", eventHandler.postEvent)
 	}
 
 	return router


### PR DESCRIPTION
I wasn't able to see the events in Segment for some reason, even after configuring a segment write key and building with `make dev-extension`. In any case though, I verified that the Segment event payload looks reasonable.

I also added a previously missing leadiong slash in the definition of the analytics events endpoint.