### PR TITLE
Fix demo request headers

### DIFF
--- a/vm/infrastructure/datasource/demo-server.go
+++ b/vm/infrastructure/datasource/demo-server.go
@@ -71,6 +71,7 @@ func (d demoServerImpl) PostTrick() error {
 
 	_, err = d.client.
 		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/json").
 		R().SetBody(body).Post(url)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes an issue where the request body sent to demo server stub `/v1/pets/{pet}/tricks/{trick}` was not recognized as valid JSON when viewed in Akita's dashboard. To fix, I've explicity set the request's content-type to `application/json`.