### PR TITLE
Add a new Analytics Event for Demo Mode

### DIFF
--- a/ui/src/views/agent/AgentPage.tsx
+++ b/ui/src/views/agent/AgentPage.tsx
@@ -83,6 +83,7 @@ export const AgentPage = () => {
 
   const handleDemoModeClick = () => {
     // Set demo mode true and clear target port and container
+    sendAnalyticsEvent("Toggled Demo Mode", { enabled: config.demo_mode_enabled });
     handleConfigChange({
       ...config,
       demo_mode_enabled: !config.demo_mode_enabled, // toggle demo mode on/off

--- a/ui/src/views/agent/AgentPage.tsx
+++ b/ui/src/views/agent/AgentPage.tsx
@@ -82,7 +82,7 @@ export const AgentPage = () => {
   };
 
   const handleDemoModeClick = () => {
-    sendAnalyticsEvent("Toggled Demo Mode", { enabled: config.demo_mode_enabled });
+    sendAnalyticsEvent("Toggled Demo Mode", { enabled: !config.demo_mode_enabled });
     // Toggle demo mode on or off and remove any targeted port or container
     handleConfigChange({
       ...config,

--- a/ui/src/views/agent/AgentPage.tsx
+++ b/ui/src/views/agent/AgentPage.tsx
@@ -82,8 +82,8 @@ export const AgentPage = () => {
   };
 
   const handleDemoModeClick = () => {
-    // Set demo mode true and clear target port and container
     sendAnalyticsEvent("Toggled Demo Mode", { enabled: config.demo_mode_enabled });
+    // Toggle demo mode on or off and remove any targeted port or container
     handleConfigChange({
       ...config,
       demo_mode_enabled: !config.demo_mode_enabled, // toggle demo mode on/off


### PR DESCRIPTION
This will cause the extension to send a new analytics event (`Toggled Demo Mode`) anytime that the demo switch is clicked.
