### PR TITLE
Push image automatically when a new release is published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish Docker Extension
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Release Tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Validate Release Tag
+        run: |
+          # Extract tag name without 'v' prefix
+          TAG_NAME=${{ github.event.release.tag_name }}
+          VERSION=${TAG_NAME#v}
+
+          echo "app_version=$VERSION" >> $GITHUB_ENV
+
+          # Check if the version (extracted from the tag name) is a valid semantic version without pre-release or metadata
+          # If so, we will publish this as the latest release on DockerHub
+          LATEST='false'
+          if echo "$VERSION" | grep -Eq  '^([0-9]+\.[0-9]+\.[0-9]+)$'; then
+            LATEST='true'
+          fi
+
+          echo "latest=$LATEST" >> $GITHUB_ENV
+
+      - name: Update app configuration
+        env:
+          SEGMENT_WRITE_KEY: ${{ secrets.segment_write_key }}
+          VERSION: ${{ env.app_version }}
+        run: |
+          # Set analytics enabled to true
+          sed -i 's/enabled: false/enabled: true/' application.yml
+
+          # Replace '<SEGMENT_WRITE_KEY>' with secret
+          sed -i "s/<SEGMENT_WRITE_KEY>/${SEGMENT_WRITE_KEY}/" application.yml
+
+          # Replace '<APP_VERSION>' with the extracted version value
+          sed -i "s/<APP_VERSION>/${VERSION}/" application.yml
+
+      - name: Login to DockerHub
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+
+
+      - name: Publish to Dockerhub
+        env:
+          TAG: ${{ env.app_version }}
+          LATEST: ${{ env.latest }}
+        run: |
+          if [ "$LATEST" = 'true' ]; then
+            make push-extension-latest
+          else
+            make push-extension
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,17 @@ jobs:
           # Replace '<APP_VERSION>' with the extracted version value
           sed -i "s/<APP_VERSION>/${VERSION}/" application.yml
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
-        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
 
       - name: Publish to Dockerhub

--- a/application.yml
+++ b/application.yml
@@ -1,7 +1,7 @@
 analytics:
   enabled: false
-  segment_write_key: <WRITE_KEY>
+  segment_write_key: <SEGMENT_WRITE_KEY>
   app:
     name: docker-extension
-    version: <SEMVER>
+    version: <APP_VERSION>
   batch_size: 1

--- a/application.yml
+++ b/application.yml
@@ -1,2 +1,7 @@
 analytics:
   enabled: false
+  segment_write_key: <WRITE_KEY>
+  app:
+    name: docker-extension
+    version: <SEMVER>
+  batch_size: 1


### PR DESCRIPTION
Very non-urgent, but hopefully this will cutdown on some of the time it takes to publish the Extension 🙂 

This will automatically push a new image to DockerHub anytime a Github release is published. It should replicate our manual deployment flow that is described here (excluding the verification step): https://www.notion.so/akitasoftware/Deploying-Docker-Extension-842700866ba74f20a357dbdcc3be642f